### PR TITLE
feat: making truth-level pt and eta cuts configurable

### DIFF
--- a/COCOA/config/config_Wlep.json
+++ b/COCOA/config/config_Wlep.json
@@ -68,6 +68,8 @@
     },
     "Fiducial_cuts":
     {
+        "pt_min": 1.0,
+        "eta_max": 3.0,
         "dR_cut": -1
     }	
 }

--- a/COCOA/config/config_default.json
+++ b/COCOA/config/config_default.json
@@ -58,7 +58,7 @@
     },
     "Fiducial_cuts":
     {
-        "pt_min": 1.0,
+        "pt_min_gev": 1.0,
         "eta_max": 3.0,
         "dR_cut": -1
     }

--- a/COCOA/config/config_default.json
+++ b/COCOA/config/config_default.json
@@ -58,6 +58,8 @@
     },
     "Fiducial_cuts":
     {
+        "pt_min": 1.0,
+        "eta_max": 3.0,
         "dR_cut": -1
     }
 

--- a/COCOA/include/Config_reader_var.hh
+++ b/COCOA/include/Config_reader_var.hh
@@ -75,6 +75,8 @@ struct Jet_parameters
 };
 struct Fiducial_cuts
 {
+    float pt_min;  // keep particles above this [GeV]
+    float eta_max; // keep particles below this
     float dR_cut;  // remove particles at truth level separated farther than dR_cut from the primary particle (used to generate single-jet data)
 };
 class Config_reader_var

--- a/COCOA/macro/Pythia8/ttbar.in
+++ b/COCOA/macro/Pythia8/ttbar.in
@@ -16,4 +16,4 @@
 
 /tracking/storeTrajectory 1
 
-/run/beamOn 2
+/run/beamOn 10

--- a/COCOA/src/Config_reader_func.cc
+++ b/COCOA/src/Config_reader_func.cc
@@ -59,6 +59,8 @@ Config_reader_func::Config_reader_func(std::string path, Config_reader_var &conf
     config_var.jet_parameter.ptmin = configs["Jet_parameters"]["ptmin"].asDouble();
     config_var.jet_parameter.radius = configs["Jet_parameters"]["radius"].asDouble();
 
+    config_var.fiducial_cuts.pt_min = configs["Fiducial_cuts"].get( "pt_min", 1.0 ).asFloat(); //GeV
+    config_var.fiducial_cuts.eta_max = configs["Fiducial_cuts"].get( "eta_max", 3.0 ).asFloat();
     config_var.fiducial_cuts.dR_cut = configs["Fiducial_cuts"].get( "dR_cut", -1.0 ).asFloat();
 
     if (config_var.Type_of_running != "Standard")

--- a/COCOA/src/Config_reader_func.cc
+++ b/COCOA/src/Config_reader_func.cc
@@ -59,7 +59,7 @@ Config_reader_func::Config_reader_func(std::string path, Config_reader_var &conf
     config_var.jet_parameter.ptmin = configs["Jet_parameters"]["ptmin"].asDouble();
     config_var.jet_parameter.radius = configs["Jet_parameters"]["radius"].asDouble();
 
-    config_var.fiducial_cuts.pt_min = configs["Fiducial_cuts"].get( "pt_min", 1.0 ).asFloat(); //GeV
+    config_var.fiducial_cuts.pt_min = configs["Fiducial_cuts"].get( "pt_min_gev", 1.0 ).asFloat();
     config_var.fiducial_cuts.eta_max = configs["Fiducial_cuts"].get( "eta_max", 3.0 ).asFloat();
     config_var.fiducial_cuts.dR_cut = configs["Fiducial_cuts"].get( "dR_cut", -1.0 ).asFloat();
 

--- a/COCOA/src/HepMCG4Interface.cc
+++ b/COCOA/src/HepMCG4Interface.cc
@@ -129,11 +129,11 @@ void HepMCG4Interface::HepMC2G4(const HepMC::GenEvent *hepmcevt,
 
 			if ((*vpitr)->status() != 1)
 				continue;
-			if ((*vpitr)->momentum().perp() < 1000.)
+			if ((*vpitr)->momentum().perp() < 1000.*config_json_var.fiducial_cuts.pt_min)
 			{
 				continue;
 			}
-			if (fabs((*vpitr)->momentum().eta()) > 3.0)
+			if (fabs((*vpitr)->momentum().eta()) > config_json_var.fiducial_cuts.eta_max)
 			{
 				continue;
 			}


### PR DESCRIPTION
Adding the following two config fields to control minimum pt and maximum absolute eta at truth level:

```
    "Fiducial_cuts":
    {
        "pt_min_gev": 1.0,  <--
        "eta_max": 3.0, <--
        "dR_cut": -1
    }	
```