### PR TITLE
fix: 4 bugs

### DIFF
--- a/COCOA/include/EventAction.hh
+++ b/COCOA/include/EventAction.hh
@@ -63,6 +63,7 @@ private:
 	Superclustering_data &superclustering_data = Superclustering_data::GetInstance();
 	Full_trajectory_info_data &trajectories = Full_trajectory_info_data::GetInstance();
 	Graph_construction_data &graph_obj = Graph_construction_data::GetLow();
+	Graph_construction_data &graph_obj_high = Graph_construction_data::GetHigh();
 	Jet_Builder_data &pflow_jets_obj = Jet_Builder_data::Get_instance_pflow();
 	Jet_Builder_data &true_jets_obj = Jet_Builder_data::Get_instance_true();
 	Jet_Builder_data &topo_jets_obj = Jet_Builder_data::Get_instance_topo();

--- a/COCOA/src/DetectorConstruction.cc
+++ b/COCOA/src/DetectorConstruction.cc
@@ -67,13 +67,7 @@ long double EtaToTheta(long double eta) {
 }
 
 long double GetPhi(long double px, long double py) {
-        long double phi = atan( fabs( py / px ) );
-	if ( px < 0.0 && py > 0.0 )
-	    phi = M_PI - phi;
-	if ( px > 0.0 && py < 0.0 )
-	    phi = 2.0 * M_PI - phi;
-	if ( px < 0.0 && py < 0.0 )
-	    phi = M_PI + phi;
+	long double phi = atan2( py, px );
 	return phi;    
 }
 

--- a/COCOA/src/EventAction.cc
+++ b/COCOA/src/EventAction.cc
@@ -69,6 +69,7 @@ void EventAction::BeginOfEventAction(const G4Event *anEvent) //const G4Event* an
 	superclustering_data.clear();
 	trajectories.clear();
 	graph_obj.clear();
+	graph_obj_high.clear();
 	true_jets_obj.clear();
 	pflow_jets_obj.clear();
 	topo_jets_obj.clear();
@@ -163,6 +164,8 @@ void EventAction::EndOfEventAction(const G4Event *evt)
 			if ( config_var.doPFlow )
 			    pflow_obj.fill_cell_var();
 			trajectories.fill_var();
+
+			GraphConstructor graph_construct_high(cells_data_high.Cells_in_topoclusters, tracks_list_low.Tracks_list, trajectories.particle_to_track, graph_obj_high);
 
 			std::vector<float> _particle_dep_energies;
 			GraphConstructor graph_construct(cells_data_low.Cells_in_topoclusters, cells_data_high.Cells_in_topoclusters, tracks_list_low.Tracks_list, trajectories.particle_to_track, graph_obj, &_particle_dep_energies);

--- a/COCOA/src/GraphConstructor.cc
+++ b/COCOA/src/GraphConstructor.cc
@@ -100,7 +100,7 @@ void GraphConstructor::fill_cell_to_cell_edges(std::vector<Cell*> &cell,
 				{
 					pq.push(cell_dr_pair);
 				}
-				else pq.pop(); //should not happen!
+				else continue;
 			}
 			else // inter-layer edges:
 			{
@@ -115,7 +115,7 @@ void GraphConstructor::fill_cell_to_cell_edges(std::vector<Cell*> &cell,
 					std::pair<float,int> cell_dr_pair_inter = std::make_pair(dr,cell_j);
 					pq_inter.push(cell_dr_pair_inter);
 				}
-				else pq_inter.pop();
+				else continue;
 			}
 
 		} // end loop over cell j

--- a/COCOA/src/Jet_Builder_data.cc
+++ b/COCOA/src/Jet_Builder_data.cc
@@ -24,7 +24,10 @@ void Jet_Builder_data::fill_cell_var()
     {
         jet_pt.push_back(jets.at(ijet).pt());
         jet_eta.push_back(jets.at(ijet).eta());
-        jet_phi.push_back(jets.at(ijet).phi());
+        float phi = jets.at(ijet).phi();
+        if (phi < -M_PI) phi += 2*M_PI;
+        if (phi > M_PI) phi -= 2*M_PI;
+        jet_phi.push_back(phi);
         jet_m.push_back(jets.at(ijet).m());
         int size_constituents = jets.at(ijet).constituents().size();
         std::vector<float> constituents;

--- a/COCOA/src/OutputRunAction.cc
+++ b/COCOA/src/OutputRunAction.cc
@@ -127,9 +127,11 @@ void OutputRunAction::BeginOfRunAction(const G4Run *run)
 			outTree_high = new TTree("High_Tree", "High_Tree");
 			Cells_data &cells_high = Cells_data::GetHigh();
 			Tracks_data &track_list_high = Tracks_data::GetHigh();
+			Graph_construction_data &graph_obj_high = Graph_construction_data::GetHigh();
 
 			cells_high.set_tree_branches(outTree_high);
 			track_list_high.set_tree_branches(outTree_high, config_var.high_resolution.kNLayers);
+			graph_obj_high.set_tree_branches(outTree_high);
 		}
 	}
 	else if (config_var.Type_of_running.find("Detector_") != string::npos)

--- a/COCOA/src/Particle_flow_data.cc
+++ b/COCOA/src/Particle_flow_data.cc
@@ -41,7 +41,10 @@ void Particle_flow_data::fill_cell_var()
     for (int ipflow = 0; ipflow < size_pflow_list; ipflow++)
     {
         pflow_eta.push_back(pflow_list.at(ipflow).eta);
-        pflow_phi.push_back(pflow_list.at(ipflow).phi);
+        float phi = pflow_list.at(ipflow).phi;
+        if (phi < -M_PI) phi += 2*M_PI;
+        if (phi > M_PI) phi -= 2*M_PI;
+        pflow_phi.push_back(phi);
         pflow_px.push_back(pflow_list.at(ipflow).px);
         pflow_py.push_back(pflow_list.at(ipflow).py);
         pflow_pz.push_back(pflow_list.at(ipflow).pz);

--- a/COCOA/src/SteppingAction.cc
+++ b/COCOA/src/SteppingAction.cc
@@ -378,7 +378,7 @@ void SteppingAction::UserSteppingAction(const G4Step *astep)
 			conv_el = new Particle_dep_in_cell;
 			conv_el->PDG_ID = trajectories.fAllConvElectrons[iConvEl].fPDGCode;
 			conv_el->particle_pos_in_true_list = iConvEl;
-			conv_el->Energy = edep;
+			conv_el->Energy = edep / samplingFraction;
 			break;
 		    }
 		}
@@ -392,7 +392,7 @@ void SteppingAction::UserSteppingAction(const G4Step *astep)
 				// runData->AddTotalEnergy(Ech, Enu);
 				Particle_dep_in_cell ptrc;
 
-				ptrc.Energy = Etot;
+				ptrc.Energy = Etot / samplingFraction;
 				ptrc.PDG_ID = trajectories.fAllTrajectoryInfo.at(mTraj).fPDGCode;
 
 				ptrc.particle_pos_in_true_list = mTraj;

--- a/COCOA/src/Topo_clust_var.cc
+++ b/COCOA/src/Topo_clust_var.cc
@@ -180,7 +180,7 @@ void Topo_clust::COM_update(Cell &cell, float weight, int add_subtract)
         cos_phi += add_subtract*fabs(cell_energy) * weight * (cos(cell.get_phi_pos()) - cos_phi) / abs_total_energy;
         sin_phi += add_subtract*fabs(cell_energy) * weight * (sin(cell.get_phi_pos()) - sin_phi) / abs_total_energy;
         R_com   += add_subtract*fabs(cell_energy) * weight * (geometry.layer_mid_radius_flatten.at(cell.get_layer()) - R_com)/abs_total_energy;
-        phi_com = atan2f(-1 * sin_phi, -1 * cos_phi) + M_PI; 
+        phi_com = atan2f(sin_phi, cos_phi);
         float argumEta = pow(cell.get_eta_pos() - eta_com, 2);
         sigma_eta_buf += add_subtract*argumEta;//!  sometimes is negative
 

--- a/COCOA/src/Track_var.cc
+++ b/COCOA/src/Track_var.cc
@@ -58,6 +58,7 @@ void Track_struct::smearing()
     q_p += sigma_qp * gRandom->Gaus(0, 1);
     theta += sigma_theta * gRandom->Gaus(0, 1);
     phiHelix += sigma_phi * gRandom->Gaus(0, 1);
+    phiHelix = phiHelix > M_PI ? phiHelix - 2 * M_PI : phiHelix < -M_PI ? phiHelix + 2 * M_PI : phiHelix;
 }
 void Track_struct::IsProductInsideRadius()
 {

--- a/COCOA/src/Tracking_func.cc
+++ b/COCOA/src/Tracking_func.cc
@@ -69,6 +69,7 @@ void Tracking::Trajectory_finder(FullTrajectoryInfo FSP, int nParticle, std::vec
             //* Perigee parametrs
             track.a0 = track.charge * (sqrt(a0sqr));
             track.phiHelix = atan2(y0, x0) + charge * M_PI_2;
+            track.phiHelix = track.phiHelix > M_PI ? track.phiHelix - 2 * M_PI : track.phiHelix < -M_PI ? track.phiHelix + 2 * M_PI : track.phiHelix;
             track.theta = acos(pz / sqrt(sqr(track.pt) + sqr(pz)));
             track.q_p = charge / sqrt(sqr(track.pt) + sqr(track.pz));
             //* numerical stability
@@ -155,8 +156,6 @@ void Tracking::Trajectory_finder(FullTrajectoryInfo FSP, int nParticle, std::vec
                 track.z_mid_layer.at(lay) = z_f;
                 track.eta.at(lay) = -1 * log(tan(0.5 * acos(z_f / sqrt(sqr(R_mid.at(lay)) + sqr(z_f)))));
                 track.phi.at(lay) = atan2(y_f, x_f);
-                if (track.phi.at(lay) < 0)
-                    track.phi.at(lay) += 2*M_PI;
                 float deta = d_eta.at(lay); //!
                 float dphi = d_phi.at(lay); //!
                 track.ind_phi.at(lay) = (int)floor(track.phi.at(lay) / dphi);
@@ -191,8 +190,6 @@ void Tracking::TrajectoryInMF(Track_struct &track, int lay)
         float Y_in_mid_layer = track.y_end_MF + track.rho_perigee * track.py_end_MF * time_to_layer;
         float Z_in_mid_layer = track.z_end_MF + track.rho_perigee * track.pz_perigee * time_to_layer;
         float Phi = atan2(Y_in_mid_layer, X_in_mid_layer);
-        if (Phi < 0)
-            Phi += 2*M_PI;
         float Eta = -1 * log(tan(0.5 * acos(Z_in_mid_layer / sqrt(sqr(X_in_mid_layer) + sqr(Y_in_mid_layer) + sqr(Z_in_mid_layer)))));
 
         float deta = d_eta.at(lay);
@@ -214,8 +211,6 @@ void Tracking::TrajectoryInMF(Track_struct &track, int lay)
         float Y_in_mid_layer = track.y_end_MF + track.py_end_MF * time_to_layer;
         float Z_in_mid_layer = track.z_end_MF + track.pz_perigee * time_to_layer;
         float Phi = atan2(Y_in_mid_layer, X_in_mid_layer);
-        if (Phi < 0)
-            Phi += 2*M_PI;
         float Eta = -1 * log(tan(0.5 * acos(Z_in_mid_layer / sqrt( sqr(R_mid.at(lay)) + sqr(Z_in_mid_layer) ) )));
 	
         float deta = d_eta.at(lay);


### PR DESCRIPTION
Fixed the following problems:
- particle deposited energy was not corrected for sampling fraction (affected `particle_to_node_weight` and `particle_dep_energy`)
- inter-layer cell-cell edges were messed up in high-granularity run
- some output phi variables were defined on [0, 2pi] instead of [-pi,pi] (`topo_bary_phi`, `particle_phi`, `particle_extrap_*`, `true_jet_phi`)
- track_phi fixed to remain in range [-pi,pi] (was spilling over to +/- 3pi/2)

Also added the saving of graph edges when running in high-granularity mode.