### PR TITLE
fix: revert Compatibility with geant4 v11

### DIFF
--- a/COCOA/include/CSVReader.hh
+++ b/COCOA/include/CSVReader.hh
@@ -2,7 +2,7 @@
 #define __CSVREADER_H__
 
 
-//#include "G4UIGAG.hh"
+#include "G4UIGAG.hh"
 #include "vector"
 #include "TH1.h"
 #include "TH2.h"

--- a/COCOA/include/OutputRunAction.hh
+++ b/COCOA/include/OutputRunAction.hh
@@ -42,11 +42,10 @@
 
 #include "globals.hh"
 // #include "DetectorGeometryDefinitions.hh"
-//#include "g4root.hh"
+#include "g4root.hh"
 // #include "DataStorage.hh"
 #include "G4Run.hh"
 #include "G4RunManager.hh"
-#include "G4AnalysisManager.hh"
 #include "G4UserRunAction.hh"
 // #include "G4UnitsTable.hh"
 #include "G4SystemOfUnits.hh"

--- a/COCOA/src/CSVReader.cc
+++ b/COCOA/src/CSVReader.cc
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-#include "G4ios.hh"
 
 CSVReader::CSVReader()
 {

--- a/COCOA/src/TrackingAction.cc
+++ b/COCOA/src/TrackingAction.cc
@@ -213,7 +213,7 @@ bool TrackingAction::IsInnerDetectorTrack(const G4Track* aTrack) const {
     G4String logicalVolumeName = aTrack->GetVolume()->GetName();
     logicalVolumeName.toLower();
     
-    return logicalVolumeName.substr( 0, 5 ) == "inner";
+    return logicalVolumeName( 0, 5 ) == "inner";
     
 }
 


### PR DESCRIPTION
Reverts cocoa-hep/cocoa-hep#44

Even though CI jobs were running well on the pull request itself, the changes broke CI when merged into main.